### PR TITLE
feat: add `slug` to `Category`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -201,13 +201,15 @@ export async function Request<T, Body>(method: Method, identifier: string | null
  * @param {number} order The order of the category
  * @param {Package[]} packages The packages in the category
  * @param {"grid" | "list" | string} display_type The display type of the category
+ * @param {string | null} slug The slug of the category
  */
 export type Category = BaseItem & {
     description: string,
     parent: Category | null,
     order: number,
     packages: Package[],
-    display_type: "grid" | "list"
+    display_type: "grid" | "list",
+    slug: string | null
 }
 
 /**

--- a/tests/Categories.test.ts
+++ b/tests/Categories.test.ts
@@ -7,7 +7,8 @@ const keys: Array<keyof Category> = [
     "parent",
     "order",
     "packages",
-    "display_type"
+    "display_type",
+    "slug"
 ]
 
 test("testCategoriesStructure", async () => {


### PR DESCRIPTION
`slug` was added to `Category` responses as of today: https://documenter.getpostman.com/view/10912536/2s9XxvTEmh#2f7c19bc-54e3-43bd-a061-8fc654555089

This PR adds `slug` to the `Category` type here so it can be used!