### PR TITLE
fix: make `AddPackageToBasket`'s `type` optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ async CreateMinecraftBasket(username: string, complete_url: string, cancel_url: 
 async GetBasketAuthUrl(basketIdent: string, returnUrl: string)
 
 // Add a package to a specific basket
-AddPackageToBasket(basketIdent: string, package_id: number, quantity: number, type: PackageType, variable_data?: KeyValuePair<string, any>)
+AddPackageToBasket(basketIdent: string, package_id: number, quantity: number, type?: PackageType, variable_data?: KeyValuePair<string, any>)
 
 // Gift a package to a target user
 async GiftPackage(basketIdent: string, package_id: number, target_username_id: string)

--- a/index.ts
+++ b/index.ts
@@ -611,7 +611,7 @@ export interface PackageBody {
  * 
  * @returns {Promise<Basket>}
  */
-export async function AddPackageToBasket(basketIdent: string, package_id: number, quantity: number, type: PackageType, variable_data?: KeyValuePair<string, any>): Promise<Basket> {
+export async function AddPackageToBasket(basketIdent: string, package_id: number, quantity: number, type?: PackageType, variable_data?: KeyValuePair<string, any>): Promise<Basket> {
     const { data }: Data<Basket> = await Request("post", basketIdent, "baskets", "/packages", {}, {
         package_id,
         quantity,


### PR DESCRIPTION
Per docs here: https://documenter.getpostman.com/view/10912536/2s9XxvTEmh#252d20fe-2fec-40df-b8a3-a9fcb071142b

```
For packages that are both single payment and subscription, type will have to be added in the body request.
Possible values: 'single' 'subscription'
```

_Most_ packages aren't `both`, so I think it makes sense to make `type` optional, which means Tebex will infer which type it should be based on the underlying package definition.