### PR TITLE
fix: update repository URL to fix publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tebex Headless API Wrapper
 
-![Tebex Headless](https://github.com/grp-gg/tebex_headless/assets/65678882/f9de08d5-aa6a-4cdf-a819-7d89d615c63b)
+![Tebex Headless](https://github.com/Tynopia/tebex_headless/assets/65678882/f9de08d5-aa6a-4cdf-a819-7d89d615c63b)
 
 Welcome to the Tebex Headless API Wrapper! This Node.js TypeScript library allows you to seamlessly integrate Tebex into your projects and build a custom storefront without revealing your use of Tebex.
 
@@ -104,7 +104,7 @@ Check out the [official Tebex documentation](https://docs.tebex.io/) for detaile
 
 ## Support
 
-If you have questions or need assistance, feel free to [open an issue](https://github.com/grp-gg/tebex_headless/issues) on the GitHub repository.
+If you have questions or need assistance, feel free to [open an issue](https://github.com/Tynopia/tebex_headless/issues) on the GitHub repository.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/grp-gg/tebex_headless.git"
+        "url": "git+https://github.com/Tynopia/tebex_headless.git"
     },
     "keywords": [
-        "grp-gg",
+        "Tynopia",
         "tebex",
         "headless",
         "api",
@@ -24,9 +24,9 @@
     "author": "Tynopia / Lukas Leisten",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/grp-gg/tebex_headless/issues"
+        "url": "https://github.com/Tynopia/tebex_headless/issues"
     },
-    "homepage": "https://github.com/grp-gg/tebex_headless#readme",
+    "homepage": "https://github.com/Tynopia/tebex_headless#readme",
     "devDependencies": {
         "@babel/preset-typescript": "^7.23.3",
         "@babel/preset-env": "^7.23.6",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "url": "git+https://github.com/Tynopia/tebex_headless.git"
     },
     "keywords": [
-        "Tynopia",
+        "tynopia",
         "tebex",
         "headless",
         "api",


### PR DESCRIPTION
As we can see here: https://github.com/Tynopia/tebex_headless/actions/runs/10457708813/job/28957942673, the publish is failing as `package.json`'s `repository` field doesn't match what the repo actually is since it was moved to your personal account.

I just went through and updated the other URLs too, but the only one that matters for publishing is `repository`.